### PR TITLE
Demonstrating bug when using collapsing toolbar in dialog

### DIFF
--- a/app/src/main/java/com/support/android/designlibdemo/CheeseRecyclerView.java
+++ b/app/src/main/java/com/support/android/designlibdemo/CheeseRecyclerView.java
@@ -1,0 +1,37 @@
+package com.support.android.designlibdemo;
+
+import android.content.Context;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.AttributeSet;
+import android.widget.Toast;
+import java.util.Arrays;
+import java.util.List;
+
+public class CheeseRecyclerView extends RecyclerView {
+
+  private Toast measureToast;
+  int measureCount;
+
+  public CheeseRecyclerView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  @Override protected void onFinishInflate() {
+    super.onFinishInflate();
+    Context context = getContext();
+    setLayoutManager(new LinearLayoutManager(context));
+    List<String> content = Arrays.asList(Cheeses.sCheeseStrings);
+    setAdapter(new CheeseListFragment.SimpleStringRecyclerViewAdapter(context, content));
+  }
+
+  @Override protected void onMeasure(int widthSpec, int heightSpec) {
+    super.onMeasure(widthSpec, heightSpec);
+    measureCount++;
+    if (measureToast != null) {
+      measureToast.cancel();
+    }
+    measureToast = Toast.makeText(getContext(), "onMeasure(): " + measureCount, Toast.LENGTH_LONG);
+    measureToast.show();
+  }
+}

--- a/app/src/main/java/com/support/android/designlibdemo/DialogCoordinatorLayout.java
+++ b/app/src/main/java/com/support/android/designlibdemo/DialogCoordinatorLayout.java
@@ -1,0 +1,25 @@
+package com.support.android.designlibdemo;
+
+import android.content.Context;
+import android.support.design.widget.CoordinatorLayout;
+import android.util.AttributeSet;
+
+import static android.view.View.MeasureSpec.EXACTLY;
+
+/**
+ * When using a {@link CoordinatorLayout} in a dialog with a header that collapses into a toolbar,
+ * somehow the {@link CoordinatorLayout} doesn't set its height to the maximum space available,
+ * it subtract the app bar height, when the app bar is in exitUntilCollapsed mode.
+ * Stupid fix here is to pretend our parent told us to use the entire height.
+ */
+public class DialogCoordinatorLayout extends CoordinatorLayout {
+  public DialogCoordinatorLayout(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  @Override protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    int height = MeasureSpec.getSize(heightMeasureSpec);
+    heightMeasureSpec = MeasureSpec.makeMeasureSpec(height, EXACTLY);
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+  }
+}

--- a/app/src/main/java/com/support/android/designlibdemo/MainActivity.java
+++ b/app/src/main/java/com/support/android/designlibdemo/MainActivity.java
@@ -28,15 +28,12 @@ import android.support.v4.view.GravityCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.Toast;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -95,6 +92,12 @@ public class MainActivity extends AppCompatActivity {
         switch (item.getItemId()) {
             case android.R.id.home:
                 mDrawerLayout.openDrawer(GravityCompat.START);
+                return true;
+            case R.id.action_broken_dialog:
+                new AlertDialog.Builder(this).setCancelable(true).setView(R.layout.broken_dialog).show();
+                return true;
+            case R.id.action_fancy_dialog:
+                new AlertDialog.Builder(this).setCancelable(true).setView(R.layout.fancy_dialog).show();
                 return true;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/res/layout/broken_dialog.xml
+++ b/app/src/main/res/layout/broken_dialog.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+  <include layout="@layout/fancy_dialog_content"/>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fancy_dialog.xml
+++ b/app/src/main/res/layout/fancy_dialog.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.support.android.designlibdemo.DialogCoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+  <include layout="@layout/fancy_dialog_content"/>
+
+</com.support.android.designlibdemo.DialogCoordinatorLayout>

--- a/app/src/main/res/layout/fancy_dialog_content.xml
+++ b/app/src/main/res/layout/fancy_dialog_content.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android" tools:showIn="@layout/fancy_dialog">
+
+
+  <android.support.design.widget.AppBarLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      >
+
+    <!--
+      Removing exitUntilCollapsed fixes the issue.
+      Displaying this layout anywhere except in a dialog fixes the issue.
+      -->
+    <android.support.design.widget.CollapsingToolbarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:title="Toolbar Title"
+        app:layout_scrollFlags="scroll|exitUntilCollapsed"
+        android:background="#ffa8ff"
+        >
+
+      <TextView
+          android:layout_width="match_parent"
+          android:layout_height="200dp"
+          android:text="Content collapsing with parallax"
+          app:layout_collapseMode="parallax"
+          android:gravity="center_horizontal"
+          />
+
+      <android.support.v7.widget.Toolbar
+          android:layout_width="match_parent"
+          android:layout_height="?actionBarSize"
+          app:layout_collapseMode="pin"/>
+
+    </android.support.design.widget.CollapsingToolbarLayout>
+  </android.support.design.widget.AppBarLayout>
+
+
+  <com.support.android.designlibdemo.CheeseRecyclerView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_behavior="@string/appbar_scrolling_view_behavior"
+      android:background="#fdf4ae"
+      />
+</merge>

--- a/app/src/main/res/menu/sample_actions.xml
+++ b/app/src/main/res/menu/sample_actions.xml
@@ -20,4 +20,12 @@
         android:id="@+id/action_settings"
         android:title="@string/menu_settings"
         app:showAsAction="never" />
+  <item
+      android:id="@+id/action_broken_dialog"
+      android:title="Broken Dialog"
+      app:showAsAction="never" />
+  <item
+      android:id="@+id/action_fancy_dialog"
+      android:title="Fancy Dialog"
+      app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
This PR adds two menu items, `Broken Dialog` and `Fancy Dialog`. Those two open a dialog with an inflating view containing a coordinator layout with a collapsing toolbar with `exitUntilCollapsed`. `Fancy Dialog` uses a hack to fix the weird problem.

In the screenshot below, you'll notice blank space below the recycler view. This was totally unexpected to me. That only occurs if the `CollapsingToolbarLayout` is using `exitUntilCollapsed`.

I also added an `onMeasure()` count to the recycler view. It's called 36 times. And 28 in the "not broken" case, when I remove `exitUntilCollapsed` or when I display the `Fancy Dialog`

The dialog is in `wrap_content` for height, so it measures with an `AT_MOST` height measure spec. I'm not sure where this remeasuring craziness comes from, but it might be the dialog trying to figure out how much it has to stretch. The CoordinatorLayout somehow decides that it doesn't need all the space the dialog can offer after all, and sets its height to the available height minus an empty space that is the height of the toolbar.

My way around this problem was to change the `CoordinatorLayout` `heightMeasureSpec` to be in `EXACTLY` mode instead of `AT_MOST`.

glhf

![screenshot-2015-10-06_05 21 41 25](https://cloud.githubusercontent.com/assets/557033/10308376/29e7999a-6bea-11e5-8a8e-e088feef1a7e.png)