### PR TITLE
Cannot hide an anchoring FAB

### DIFF
--- a/app/src/main/java/com/support/android/designlibdemo/CheeseDetailActivity.java
+++ b/app/src/main/java/com/support/android/designlibdemo/CheeseDetailActivity.java
@@ -19,10 +19,12 @@ package com.support.android.designlibdemo;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.CollapsingToolbarLayout;
+import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ImageView;
 
 import com.bumptech.glide.Glide;
@@ -48,6 +50,10 @@ public class CheeseDetailActivity extends AppCompatActivity {
         CollapsingToolbarLayout collapsingToolbar =
                 (CollapsingToolbarLayout) findViewById(R.id.collapsing_toolbar);
         collapsingToolbar.setTitle(cheeseName);
+
+        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
+        fab.setAlpha(0f);
+        fab.setVisibility(View.GONE);
 
         loadBackdrop();
     }

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -153,12 +153,15 @@
     </android.support.v4.widget.NestedScrollView>
 
     <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
         app:layout_anchor="@id/appbar"
         app:layout_anchorGravity="bottom|right|end"
         android:src="@drawable/ic_discuss"
         android:layout_margin="@dimen/fab_margin"
+        android:alpha="0"
+        android:visibility="gone"
         android:clickable="true"/>
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
You cannot hide an anchoring FAB on start, neither using visibility nor using alpha, neither in XML nor in Java.

And I don't believe it is the intended behavior to keep a FAB always totally visible on my start up.

This is important for animation stuff, for example a delayed scale up animation will show a glitch of the FAB if it cannot be initially hidden.

I tested on my Samsung S4 5.0.1, an API 15 emulator and an API 17 emulator, all showing the FAB that should have been made hidden for four times.
