### PR TITLE
Snackbar listener for the action to show up

### DIFF
--- a/app/src/main/java/com/support/android/designlibdemo/MainActivity.java
+++ b/app/src/main/java/com/support/android/designlibdemo/MainActivity.java
@@ -76,7 +76,12 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 Snackbar.make(view, "Here's a Snackbar", Snackbar.LENGTH_LONG)
-                        .setAction("Action", null).show();
+                        .setAction("Action", new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
+                                // Do nothing
+                            }
+                        }).show();
             }
         });
 


### PR DESCRIPTION
When the action is given a null listener, the Snackbar by default does not show the action added. So I've added a listener that does nothing to properly show the full demonstration of how to use a Snackbar.