### PR TITLE
Shared element transition animation moves image to incorrect location when target activity contains CollapsingToolbarLayout 

### DIFF
--- a/app/src/main/java/com/support/android/designlibdemo/CheeseDetailActivity.java
+++ b/app/src/main/java/com/support/android/designlibdemo/CheeseDetailActivity.java
@@ -32,6 +32,8 @@ import java.util.Random;
 public class CheeseDetailActivity extends AppCompatActivity {
 
     public static final String EXTRA_NAME = "cheese_name";
+    // For duplicating shared element transition image.
+    public static final String EXTRA_DRAWABLE_ID = "drawable_id";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -48,6 +50,13 @@ public class CheeseDetailActivity extends AppCompatActivity {
         CollapsingToolbarLayout collapsingToolbar =
                 (CollapsingToolbarLayout) findViewById(R.id.collapsing_toolbar);
         collapsingToolbar.setTitle(cheeseName);
+
+        // Duplicate shared element transition image.
+        int drawableId = intent.getIntExtra(EXTRA_DRAWABLE_ID, -1);
+        if (drawableId != -1) {
+            final ImageView imageView = (ImageView) findViewById(R.id.avatar);
+            Glide.with(this).load(drawableId).fitCenter().into(imageView);
+        }
 
         loadBackdrop();
     }

--- a/app/src/main/java/com/support/android/designlibdemo/CheeseListFragment.java
+++ b/app/src/main/java/com/support/android/designlibdemo/CheeseListFragment.java
@@ -16,10 +16,14 @@
 
 package com.support.android.designlibdemo;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.LinearLayoutManager;
@@ -72,6 +76,8 @@ public class CheeseListFragment extends Fragment {
 
         public static class ViewHolder extends RecyclerView.ViewHolder {
             public String mBoundString;
+            // Image view drawable id to share with detail activity
+            public int mDrawableId;
 
             public final View mView;
             public final ImageView mImageView;
@@ -120,14 +126,41 @@ public class CheeseListFragment extends Fragment {
                     Intent intent = new Intent(context, CheeseDetailActivity.class);
                     intent.putExtra(CheeseDetailActivity.EXTRA_NAME, holder.mBoundString);
 
-                    context.startActivity(intent);
+                    // Setup standard shared element transition for list item image.
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        intent.putExtra(CheeseDetailActivity.EXTRA_DRAWABLE_ID,
+                                holder.mDrawableId);
+                        holder.mImageView.setTransitionName("sharedImage");
+                        ActivityOptionsCompat options = ActivityOptionsCompat.
+                                makeSceneTransitionAnimation(
+                                        getActivity(v.getContext()), // See helper below
+                                        holder.mImageView,
+                                        "sharedImage");
+                        context.startActivity(intent, options.toBundle());
+                    } else {
+                        context.startActivity(intent);
+                    }
                 }
             });
 
+            // Save drawable id to forward to detail activity.
+            holder.mDrawableId = Cheeses.getRandomCheeseDrawable();
             Glide.with(holder.mImageView.getContext())
-                    .load(Cheeses.getRandomCheeseDrawable())
+                    .load(holder.mDrawableId)
                     .fitCenter()
                     .into(holder.mImageView);
+        }
+
+        // Helper that traverses up context chain to retrieve the activity
+        // that is used in the shared element transition in onClick() above.
+        private Activity getActivity(Context context) {
+            while (context instanceof ContextWrapper) {
+                if (context instanceof Activity) {
+                    return (Activity)context;
+                }
+                context = ((ContextWrapper)context).getBaseContext();
+            }
+            return null;
         }
 
         @Override

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -79,6 +79,14 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
+                    <!-- copied from list_item.xml: added android:transitionName -->
+                    <de.hdodenhof.circleimageview.CircleImageView
+                        android:id="@+id/avatar"
+                        android:layout_width="@dimen/list_item_avatar_size"
+                        android:layout_height="@dimen/list_item_avatar_size"
+                        android:transitionName="sharedImage"
+                        android:layout_marginRight="16dp"/>
+
                     <TextView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
Example code that shows how a simple shared element transition animation to a target activity that contains a CollapsingToolbarLayout will cause a source image to animate to a slightly lower vertical location than the actual target image view in the destination activity. The vertical offset error seems to be roughly equal to  the height of a default ActionBar. Once the animation completes, the image appears to "warp" into the correct position (which is simply an illusion). For a more detailed description of this problem please see my stackoverlow post (posted 3 weeks ago):

http://stackoverflow.com/questions/33062613/shared-element-transitions-not-working-when-combined-with-a-coordinatorlayout-an

I can log this in the Android Open Source Issue Tracker if you wold prefer, but I thought this might be useful to you as a pull request to easily demonstrate the problem. I compiled and tested this using Android Studio 1.4 without modifying any of the project default settings.

Thank you
Monte Creasor (Git name: WoodyElf).