### PR TITLE
Added android:fitsSystemWindows="true" to NestedScrollView to allow animations to work

### DIFF
--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -61,6 +61,7 @@
     <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout


### PR DESCRIPTION
The android:fitsSystemWindows="true" parameter should be propagated down to the inner most container which in this case is a NestedScrollView. Failing do do so will cause any shared element animations to miscalculate the location of the target element in the target activity.